### PR TITLE
move to fasttext `0.9.2` to address memory leak in python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ grpcio==1.26.0
 grpcio-tools==1.26.0
 grpcio-health-checking==1.26.0
 watchdog==0.10.1
-fasttext==0.9.1
+fasttext==0.9.2


### PR DESCRIPTION
bump to `0.9.2` to address a [memory leak issue in `0.9.1`](https://github.com/facebookresearch/fastText/commit/40a77442a756ab160ae3465b26322f6e480405d9)